### PR TITLE
Fix missing nginx runtime dependency: libyajl

### DIFF
--- a/rpms/SPECS/nginx/nginx.spec
+++ b/rpms/SPECS/nginx/nginx.spec
@@ -153,6 +153,7 @@ Requires:          gd
 Requires:          openssl
 Requires:          pcre
 Requires:          perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
+Requires:          yajl
 Requires(pre):     nginx-filesystem
 Provides:          webserver = %{version}
 Provides:          %{name} = %{version}-%{release}


### PR DESCRIPTION
Hi.

This is a fix for nginx error:

```
nginx: error while loading shared libraries: libyajl.so.2: cannot open shared object file: No such file or directory
```
