### PR TITLE
Add Requires: gvfs - to fix not being able to delete files in tree

### DIFF
--- a/rpms/atom/atom.spec
+++ b/rpms/atom/atom.spec
@@ -44,6 +44,7 @@ BuildRequires: nodejs-atom-package-manager
 Requires: nodejs-atom-package-manager
 Requires: electron = %{electron_ver}
 Requires: desktop-file-utils
+Requires: gvfs
 
 %description
 Atom is a text editor that's modern, approachable, yet hack-able to the core


### PR DESCRIPTION
Atom requires gvfs in order to be able to send items to the trashbin, an error is caused without this package present.

Error: "The following file couldn't be moved to trash (is gvfs-trash installed?)"
