### PR TITLE
Update package repo url

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,7 +358,7 @@ tbody tr:hover{
 <div id="wrapper">
     <div id="filelist">
         <h3 style="clear:left; display: inline-block;">软件包列表</h3>
-        <a style="float:right;" href="//repo.fdzh.org/FZUG">浏览软件仓库</a>
+        <a style="float:right;" href="//mirrors.tuna.tsinghua.edu.cn/fzug/">浏览软件仓库</a>
         <hr />
         <table cellspacing="0" cellpadding="0" class="filelist">
             <thead>

--- a/index.html
+++ b/index.html
@@ -652,7 +652,7 @@ tbody tr:hover{
 
         <div id="footerleft">
             <p>Fedora 中文社区 (FZUG) 由世界各地讲中文的 Fedora 爱好者组成。点击了解中文社区<a href="//github.com/FZUG">开源项目</a>与<a href="//fedoraproject.org/wiki/FZUGCommunicate">沟通方式</a>。</p>
-            <p>本软件源由 <a href="//www.ucloud.cn/?ref=fdzh.org" target="_blank" data-original-title="服务器由 UCloud 赞助"><img height="10%" width="15%" src="img/ucloud.png" alt="UCloud"></a> 提供服务器资源赞助，由 <a href="http://www.qiniu.com/?ref=fdzh.org" target="_blank" data-original-title="QINIU CDN"><img height="10%" width="15%" src="img/qiniu-125x55.png" alt="QINIU"></a> 提供 CDN 服务支持。<!--www.b1.qiniudn.com/images/logo-3.png--></p>
+            <p>本软件源由 <a href="//tuna.moe"><img src="https://tuna.moe/assets/img/logo-small.png" srcset="https://tuna.moe/assets/img/logo-small.png 1x, https://tuna.moe/assets/img/logo-small@2x.png 2x, https://tuna.moe/assets/img/logo-small@3x.png 3x, https://tuna.moe/assets/img/logo-small@4x.png 4x" alt="清华大学 TUNA 协会"></a> 提供镜像支持。</p>
             <p>本网站主题在 <a href="//moeka.me" target="_blank">Miaomiao Li</a> 设计的 <a href="//mirrors.ustc.edu.cn/">USTC 开源镜像站主页</a>基础上定制而成。</p>
             <p>Copyright &copy; 2015, 2018 FZUG</p>
         </div>

--- a/index.html
+++ b/index.html
@@ -616,24 +616,11 @@ tbody tr:hover{
 
 
 <div id="sidebar">
-<!--<div id="cdimages">
-            <h3>获取 Fedora 镜像</h3>
-            <p>Fedora 分为 Workstation, Server, Cloud 三个版本，请根据需要选择：</p>
-            <p></p>
-            <span onclick="window.open('https://getfedora.org')" class="btn">获取安装镜像 &gt;</span>
-        </div>
--->
         <div id="mirrorshelp">
             <h3>使用指南</h3>
             <span onclick="window.open('//github.com/FZUG/repo/wiki')" class="btn">软件源配置 Wiki</span>
        <span></span>
         </div>
-<!--
-        <div id="mirrorlinks">
-            <a target="_blank" href="http://fdzh.org/chromewiki">Chrome 源配置 Wiki</a><br>
-            <span></span>
-        </div>
--->
         <div id="mirrorlinks">
             <h3>使用截图</h3>
             <a target="_blank" href="img/snapshot1.png"><img src="img/snapshot1.png" title="Fedora 22 beautiful face" alt="Fedora 22 桌面" width="60%"/></a>


### PR DESCRIPTION
Now that the update to repo.fdzh.org is stuck and new releases only present at tuna, it is time to update the links. Otherwise, there will be more confusion to users.